### PR TITLE
Add index=pas to setup.xml department search

### DIFF
--- a/apps/pas_ref_app/default/data/ui/views/setup.xml
+++ b/apps/pas_ref_app/default/data/ui/views/setup.xml
@@ -3,7 +3,7 @@
     <label>Setup</label>
     <search id="departments_search">
         <query>
-            tag=pas tag=change tag=audit | stats count by department
+            index=pas tag=pas tag=change tag=audit | stats count by department
         </query>
         <earliest>@d</earliest>
         <latest>now</latest>


### PR DESCRIPTION
Cloud demo users do not install and setup via the readme, so the steps to add a given username to the pasuser group are not shown. Since you're not initially a member, the search as written without an index will not include the pas index, so the searchbox to select departments for the dashboard won't work.

Adding the index to the search resolves the problem more easily than having users add themselves to a group, making it easier for new users to consume.